### PR TITLE
Bump indy-sdk version to 1.8.2.

### DIFF
--- a/ci/indy-pool.dockerfile
+++ b/ci/indy-pool.dockerfile
@@ -1,4 +1,4 @@
-# This dockerfile originates from indy-sdk: https://github.com/hyperledger/indy-sdk/blob/v1.6.6/ci/indy-pool.dockerfile
+# This dockerfile originates from indy-sdk: https://github.com/hyperledger/indy-sdk/blob/v1.8.2/ci/indy-pool.dockerfile
 
 FROM ubuntu:16.04
 
@@ -26,11 +26,11 @@ RUN echo "deb https://repo.sovrin.org/deb xenial $indy_stream" >> /etc/apt/sourc
 
 RUN useradd -ms /bin/bash -u $uid indy
 
-ARG indy_plenum_ver=1.6.520
+ARG indy_plenum_ver=1.6.726
 ARG indy_anoncreds_ver=1.0.32
-ARG indy_node_ver=1.6.576
-ARG python3_indy_crypto_ver=0.4.3
-ARG indy_crypto_ver=0.4.3
+ARG indy_node_ver=1.6.862
+ARG python3_indy_crypto_ver=0.4.5
+ARG indy_crypto_ver=0.4.5
 
 RUN apt-get update -y && apt-get install -y \
         indy-plenum=${indy_plenum_ver} \

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <repositories>
         <repository>
-            <id>evernym</id>
+            <id>sovrin</id>
             <url>https://repo.sovrin.org/repository/maven-public</url>
         </repository>
     </repositories>
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.hyperledger</groupId>
             <artifactId>indy</artifactId>
-            <version>1.6.6</version>
+            <version>1.8.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Updated indy-sdk dependency to 1.8.2.
Additionally, the maven repository name has been corrected, as it is no longer pointing to the evernym repository.

Since indy_crypto_anon_crypt is deperecated as of indy-sdk 1.8, a new issue should be made to migrate to indy_pack_message. See: https://github.com/hyperledger/indy-sdk/blob/master/docs/migration-guides/migration-guide-1.7.0-1.8.0.md