### PR TITLE
Switch to not storing the did on the ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ hs_err_pid*
 # build directory
 target/
 LOG_FILE_IS_UNDEFINED
+
+# maven version plugin backup
+*.versionsBackup

--- a/src/main/java/nl/quintor/studybits/indy/wrapper/TrustAnchor.java
+++ b/src/main/java/nl/quintor/studybits/indy/wrapper/TrustAnchor.java
@@ -43,17 +43,10 @@ public class TrustAnchor extends IndyWallet {
     public CompletableFuture<ConnectionResponse> acceptConnectionRequest(ConnectionRequest connectionRequest) throws JsonProcessingException, IndyException {
         log.debug("{} Called acceptConnectionRequest with {}", name, connectionRequest);
 
-        // Pairwise connections are always without a role
-        CompletableFuture<String> sendTheirNym = sendNym(connectionRequest.getDid(), connectionRequest.getVerkey(), null);
-
-        CompletableFuture<ConnectionResponse> createAndSendMyNym = newDid()
+        return newDid()
                 .thenCompose(wrapException(result ->
-                                storeDidAndPairwise(result.getDid(), connectionRequest.getDid())
-                        .thenCompose(wrapException(_void -> sendNym(result.getDid(), result.getVerkey(), null)))
-                        .thenApply(((_str) -> new ConnectionResponse(result.getDid())))));
-
-        return CompletableFuture.allOf(sendTheirNym, createAndSendMyNym)
-                .thenCompose(_void -> createAndSendMyNym);
+                        storeDidAndPairwise(result.getDid(), connectionRequest.getDid(), connectionRequest.getVerkey())
+                                .thenApply(((_str) -> new ConnectionResponse(result.getDid(), result.getVerkey())))));
     }
 
     CompletableFuture<String> sendNym(String newDid, String newKey, String role) throws IndyException {

--- a/src/main/java/nl/quintor/studybits/indy/wrapper/dto/ConnectionResponse.java
+++ b/src/main/java/nl/quintor/studybits/indy/wrapper/dto/ConnectionResponse.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ConnectionResponse implements Serializable {
     private String did;
+    private String verkey;
 }


### PR DESCRIPTION
Pairwise DIDs are now now longer stored on the ledger.

There is no parameter to actually store them, if you want to store a
did on ledger, create a verinym and call acceptVerinymRequest instead.

Fixes #26 